### PR TITLE
Fixes for #expand_hash method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.3.0)
+    umbrellio-utils (0.3.1)
       memery (~> 1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport
   bundler
   bundler-audit
   ci-helper

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Some modules and classes are configurable. Here's the full list of settings and 
   `UmbrellioUtils::HTTPClient`. Defaults to `:application_httpclient`
 
 You can change config in two ways. Firstly, you can change values by accessing configuration
-directly. Secondly, you can use `UmbrellioUtils::configure` method, which accepts a block.
+directly. Secondly, you can use `UmbrellioUtils::configure` method which accepts a block.
 
 ```ruby
 

--- a/lib/umbrellio_utils/formatting.rb
+++ b/lib/umbrellio_utils/formatting.rb
@@ -72,7 +72,7 @@ module UmbrellioUtils
     # @return [Hash] expanded hash
     #
     def expand_hash(hash, delemiter: ".", key_converter: :to_sym)
-      hash.each_with_object(Misc.build_infinite_hash) do |entry, memo|
+      result = hash.each_with_object(Misc.build_infinite_hash) do |entry, memo|
         path, value = entry
         *path_to_key, key = path.to_s.split(delemiter).map(&key_converter)
 
@@ -83,6 +83,8 @@ module UmbrellioUtils
           resolved_hash[key] = value
         end
       end
+
+      Misc.reset_defaults_for_hash(result)
     end
 
     #

--- a/lib/umbrellio_utils/formatting.rb
+++ b/lib/umbrellio_utils/formatting.rb
@@ -64,17 +64,17 @@ module UmbrellioUtils
     #
     # Expands a hash whose keys contain the path.
     #
-    # @param [Hash] hash hash, which you want to expand
-    # @param [String] delemiter, separator, which is used in the value of the keys
-    # @param [Proc, Lambda, Symbol] key_converter, converter for key's value.
+    # @param hash [Hash] hash which you want to expand
+    # @param delimiter [String] separator which is used in the value of the keys
+    # @param key_converter [Proc, Lambda, Symbol] converter for key's value.
     #  Defaults to :to_sym
     #
     # @return [Hash] expanded hash
     #
-    def expand_hash(hash, delemiter: ".", key_converter: :to_sym)
+    def expand_hash(hash, delimiter: ".", key_converter: :to_sym)
       result = hash.each_with_object(Misc.build_infinite_hash) do |entry, memo|
         path, value = entry
-        *path_to_key, key = path.to_s.split(delemiter).map(&key_converter)
+        *path_to_key, key = path.to_s.split(delimiter).map(&key_converter)
 
         if path_to_key.empty?
           memo[key] = value
@@ -90,8 +90,8 @@ module UmbrellioUtils
     #
     # Expands a nested hash whose keys contain the path.
     #
-    # @param [Hash] hash, hash, which you want to expand
-    # @param [Hash] **expand_hash_options options, that the
+    # @param hash [Hash] hash which you want to expand
+    # @param **expand_hash_options [Hash] options, that the
     #  {#expand_hash} method accepts
     #
     # @return [Hash] expanded hash

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -28,5 +28,25 @@ module UmbrellioUtils
     def build_infinite_hash
       Hash.new { |hash, key| hash[key] = Hash.new(&hash.default_proc) }
     end
+
+    #
+    # Sets #default and #default_proc values to nil.
+    #
+    # @param [Hash] hash, hash, for which you want to reset defaults.
+    #
+    # @return [Hash] resetted hash.
+    #
+    def reset_defaults_for_hash(hash)
+      hash.dup.tap do |dup_hash|
+        dup_hash.default = nil
+        dup_hash.default_proc = nil
+
+        dup_hash.transform_values! do |obj|
+          next obj.deep_dup unless obj.is_a?(Hash)
+
+          reset_defaults_for_hash(obj)
+        end
+      end
+    end
   end
 end

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -25,6 +25,18 @@ module UmbrellioUtils
       ranges.first.zip(*ranges[1..]).map { |x| x.find(&:present?) }
     end
 
+    #
+    # Builds empty hash, which recursively returns empty hash, if key is not found.
+    # Also note, that this hash and all subhashes has set #default_proc.
+    # To reset this attribute use {#reset_defaults_for_hash}
+    #
+    # @example Dig to key
+    #  h = UmbrellioUtils::Misc.build_infinite_hash => {}
+    #  h.dig(:kek, :pek) => {}
+    #  h => { kek: { pek: {} } }
+    #
+    # @return [Hash] empty infinite hash.
+    #
     def build_infinite_hash
       Hash.new { |hash, key| hash[key] = Hash.new(&hash.default_proc) }
     end
@@ -32,7 +44,7 @@ module UmbrellioUtils
     #
     # Deeply sets #default and #default_proc values to nil.
     #
-    # @param [Hash] hash, hash, for which you want to reset defaults.
+    # @param [Hash] hash hash, for which you want to reset defaults.
     #
     # @return [Hash] resetted hash.
     #

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module UmbrellioUtils
+module
   module Misc
     extend self
 
@@ -30,7 +30,7 @@ module UmbrellioUtils
     end
 
     #
-    # Sets #default and #default_proc values to nil.
+    # Deeply sets #default and #default_proc values to nil.
     #
     # @param [Hash] hash, hash, for which you want to reset defaults.
     #

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module
+module UmbrellioUtils
   module Misc
     extend self
 

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -19,14 +19,16 @@ module UmbrellioUtils
       end
     end
 
+    #
     # Ranges go from high to low priority
+    #
     def merge_ranges(*ranges)
       ranges = ranges.map { |x| x.present? && x.size == 2 ? x : [nil, nil] }
       ranges.first.zip(*ranges[1..]).map { |x| x.find(&:present?) }
     end
 
     #
-    # Builds empty hash, which recursively returns empty hash, if key is not found.
+    # Builds empty hash which recursively returns empty hash, if key is not found.
     # Also note, that this hash and all subhashes has set #default_proc.
     # To reset this attribute use {#reset_defaults_for_hash}
     #
@@ -44,9 +46,9 @@ module UmbrellioUtils
     #
     # Deeply sets #default and #default_proc values to nil.
     #
-    # @param [Hash] hash hash, for which you want to reset defaults.
+    # @param hash [Hash] hash for which you want to reset defaults.
     #
-    # @return [Hash] resetted hash.
+    # @return [Hash] reset hash.
     #
     def reset_defaults_for_hash(hash)
       hash.dup.tap do |dup_hash|

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ SimpleCov.enable_coverage(:line)
 SimpleCov.add_filter "spec"
 SimpleCov.start
 
+require "active_support/all"
 require "umbrellio-utils"
 
 Dir[Pathname(__dir__).join("support/**/*")].sort.each { |x| require(x) }

--- a/spec/umbrellio_utils/formatting_spec.rb
+++ b/spec/umbrellio_utils/formatting_spec.rb
@@ -15,7 +15,7 @@ describe UmbrellioUtils::Formatting do
 
     context "with other delimiter" do
       let(:hash) { Hash["deep,first": true, "deep,second": false, root: "kek"] }
-      let(:kwargs) { Hash[delemiter: ","] }
+      let(:kwargs) { Hash[delimiter: ","] }
 
       specify { is_expected.to eq(deep: { first: true, second: false }, root: "kek") }
     end

--- a/spec/umbrellio_utils/formatting_spec.rb
+++ b/spec/umbrellio_utils/formatting_spec.rb
@@ -7,7 +7,11 @@ describe UmbrellioUtils::Formatting do
     let(:hash) { Hash["deep.first": true, "deep.second": false, root: "kek"] }
     let(:kwargs) { Hash[] }
 
-    specify { is_expected.to eq(deep: { first: true, second: false }, root: "kek") }
+    it "properly expands and resets defaults" do
+      expect(expanded_hash).to eq(deep: { first: true, second: false }, root: "kek")
+      expect(expanded_hash.default_proc).to eq(nil)
+      expect(expanded_hash[:deep].default_proc).to eq(nil)
+    end
 
     context "with other delimiter" do
       let(:hash) { Hash["deep,first": true, "deep,second": false, root: "kek"] }

--- a/umbrellio_utils.gemspec
+++ b/umbrellio_utils.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "memery", "~> 1"
 
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "bundler-audit"
   spec.add_development_dependency "ci-helper"


### PR DESCRIPTION
# Changes

## New methods

- `UmbrellioUtils::Misc#reset_defaults_for_hash` - Deeply sets #default and #default_proc values to nil.

## Fixes

- `UmbrellioUtils::Formatting#expand_hash` and `UmbrellioUtils::Formatting#deeply_expand_hash` return hash with retested defaults.