### PR TITLE
Make TinyJsonFormatter more confirugable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     dry-inflector (0.2.1)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
+    json (2.6.1)
     memery (1.4.1)
       ruby2_keywords (~> 0.0.2)
     method_source (1.0.0)
@@ -46,7 +46,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.6)
@@ -104,7 +104,7 @@ GEM
     ruby2_keywords (0.0.5)
     semantic_logger (4.8.2)
       concurrent-ruby (~> 1.0)
-    sequel (5.48.0)
+    sequel (5.49.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -121,7 +121,7 @@ GEM
       symbiont-ruby
     unicode-display_width (2.1.0)
     yard (0.9.26)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   x86_64-darwin-20
@@ -146,4 +146,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.28
+   2.2.29

--- a/lib/umbrellio_utils/semantic_logger/tiny_json_formatter.rb
+++ b/lib/umbrellio_utils/semantic_logger/tiny_json_formatter.rb
@@ -9,6 +9,35 @@ module UmbrellioUtils
     #   formatter = UmbrellioUtils::SemanticLogger::TinyJsonFormatter.new
     #   SemanticLogger.add_appender(io: $stdout, formatter: formatter)
     class TinyJsonFormatter
+      # Hash with default field names in the output JSON.
+      DEFAULT_NAMES_MAPPING = {
+        severity: :severity,
+        name: :name,
+        thread_fingerprint: :thread_fingerprint,
+        message: :message,
+        app_tags: :app_tags,
+        time: :time,
+      }.freeze
+
+      # Returns a new instance of the {UmbrellioUtils::SemanticLogger::TinyJsonFormatter}.
+      # @param [Hash] custom_names_mapping mapping from default field names to custom ones.
+      # @option custom_names_mapping [Symbol] :severity custom name for the `severity` field.
+      # @option custom_names_mapping [Symbol] :name custom name for the `name` field.
+      # @option custom_names_mapping [Symbol] :thread_fingerprint
+      #   custom name for the thread_fingerprint field.
+      # @option custom_names_mapping [Symbol] :message custom name for the `message` field.
+      # @option custom_names_mapping [Symbol] :app_tags custom name for the `app_tags` field.
+      # @option custom_names_mapping [Symbol] :time custom name for the `time` field.
+      # @example Use custom name for the `message` and `time` fields
+      #   UmbrellioUtils::SemanticLogger::TinyJsonFormatter.new(
+      #     time: :timestamp, message: :note,
+      #   ) #=> <UmbrellioUtils::SemanticLogger::TinyJsonFormatter:0x000>
+      # @return [UmbrellioUtils::SemanticLogger::TinyJsonFormatter]
+      #   a new instance of the {UmbrellioUtils::SemanticLogger::TinyJsonFormatter}
+      def initialize(**custom_names_mapping)
+        self.field_names = { **DEFAULT_NAMES_MAPPING, **custom_names_mapping }.freeze
+      end
+
       # Formats log structure into the JSON string.
       # @param log [SemanticLogger::Log] log's data structure.
       # @param logger [SemanticLogger::Logger] active logger.
@@ -20,21 +49,33 @@ module UmbrellioUtils
 
       private
 
+      # @!attribute field_names
+      #   @return [Hash<Symbol, Symbol>] the mapping from default field names to the new ones.
+      attr_accessor :field_names
+
       # Builds hash with data from log.
-      # @private
+      # @return [Hash] the hash, which will be converted to the JSON later.
       def build_data_for(log)
-        {
-          severity: log.level.upcase,
-          name: log.name,
-          thread_fingerprint: thread_fingerprint_for(log),
-          message: log.message,
-          tags: log.named_tags,
-          time: log.time.utc.iso8601(3),
-        }
+        field_names.values_at(*DEFAULT_NAMES_MAPPING.keys).zip(pack_data(log)).to_h
+      end
+
+      # Builds an [Array] with all the required fields, which are arranged
+      # in the order of the declaration of keys
+      # in the {UmbrellioUtils::SemanticLogger::TinyJsonFormatter::DEFAULT_NAMES_MAPPING}.
+      # @return [Array] an array with serialized data.
+      def pack_data(log)
+        [
+          log.level.upcase,
+          log.name,
+          thread_fingerprint_for(log),
+          log.message,
+          log.named_tags,
+          log.time.utc.iso8601(3),
+        ]
       end
 
       # Calculates MD5 fingerprint for the thread, in which the log was made.
-      # @private
+      # @return [String] truncated `MD5` hash.
       def thread_fingerprint_for(log)
         Digest::MD5.hexdigest("#{log.thread_name}#{Process.pid}")[0...8]
       end


### PR DESCRIPTION
# Changes

## Features

- Implemented the ability to change the names of fields in the resulting `JSON`.

## Fixes

- Rename default field names because of conflicting indexes.