### PR TITLE
Fix field naming for logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.4.0)
+    umbrellio-utils (0.4.1)
       memery (~> 1)
 
 GEM
@@ -35,8 +35,6 @@ GEM
       ruby2_keywords (~> 0.0.2)
     method_source (1.0.0)
     minitest (5.14.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     nori (2.6.0)
@@ -146,4 +144,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.29
+   2.2.30

--- a/lib/umbrellio_utils/semantic_logger/tiny_json_formatter.rb
+++ b/lib/umbrellio_utils/semantic_logger/tiny_json_formatter.rb
@@ -15,7 +15,8 @@ module UmbrellioUtils
         name: :name,
         thread_fingerprint: :thread_fingerprint,
         message: :message,
-        app_tags: :app_tags,
+        tags: :tags,
+        named_tags: :named_tags,
         time: :time,
       }.freeze
 
@@ -26,7 +27,8 @@ module UmbrellioUtils
       # @option custom_names_mapping [Symbol] :thread_fingerprint
       #   custom name for the thread_fingerprint field.
       # @option custom_names_mapping [Symbol] :message custom name for the `message` field.
-      # @option custom_names_mapping [Symbol] :app_tags custom name for the `app_tags` field.
+      # @option custom_names_mapping [Symbol] :tags custom name for the `tags` field.
+      # @option custom_names_mapping [Symbol] :named_tags custom name for the `named_tags` field.
       # @option custom_names_mapping [Symbol] :time custom name for the `time` field.
       # @example Use custom name for the `message` and `time` fields
       #   UmbrellioUtils::SemanticLogger::TinyJsonFormatter.new(
@@ -69,6 +71,7 @@ module UmbrellioUtils
           log.name,
           thread_fingerprint_for(log),
           log.message,
+          log.tags,
           log.named_tags,
           log.time.utc.iso8601(3),
         ]

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/umbrellio_utils/semantic_logger/tiny_json_formatter_spec.rb
+++ b/spec/umbrellio_utils/semantic_logger/tiny_json_formatter_spec.rb
@@ -90,7 +90,7 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
         message: "Some Message",
         time: "2007-01-01T00:00:00.000Z",
         tags: ["kek"],
-        named_tags: { id:  "very-long-id" },
+        named_tags: { id: "very-long-id" },
       )
     end
   end

--- a/spec/umbrellio_utils/semantic_logger/tiny_json_formatter_spec.rb
+++ b/spec/umbrellio_utils/semantic_logger/tiny_json_formatter_spec.rb
@@ -16,6 +16,7 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
       allow(instance).to receive(:name).and_return(log_name)
       allow(instance).to receive(:thread_name).and_return(log_thread_name)
       allow(instance).to receive(:message).and_return(log_message)
+      allow(instance).to receive(:tags).and_return(log_tags)
       allow(instance).to receive(:named_tags).and_return(log_named_tags)
       allow(instance).to receive(:time).and_return(log_time)
     end
@@ -29,6 +30,7 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
   let(:log_name) { "SomeName" }
   let(:log_thread_name) { "10706" }
   let(:log_message) { "Some Message" }
+  let(:log_tags) { [] }
   let(:log_named_tags) { Hash[] }
   let(:log_time) { Time.utc(2007) }
 
@@ -39,7 +41,8 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
       thread_fingerprint: "85bb6139",
       message: "Some Message",
       time: "2007-01-01T00:00:00.000Z",
-      app_tags: {},
+      tags: [],
+      named_tags: {},
     )
   end
 
@@ -53,7 +56,8 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
         thread_fingerprint: "85bb6139",
         note: "Some Message",
         timestamp: "2007-01-01T00:00:00.000Z",
-        app_tags: {},
+        tags: [],
+        named_tags: {},
       )
     end
   end
@@ -68,7 +72,25 @@ describe UmbrellioUtils::SemanticLogger::TinyJsonFormatter do
         thread_fingerprint: "85bb6139",
         message: "Some Message",
         time: "2007-01-01T00:00:00.000Z",
-        app_tags: {},
+        tags: [],
+        named_tags: {},
+      )
+    end
+  end
+
+  context "with active tags" do
+    let(:log_tags) { ["kek"] }
+    let(:log_named_tags) { Hash[id: "very-long-id"] }
+
+    it "properly renders this tags" do
+      expect(result).to be_json_as(
+        severity: "DEBUG",
+        name: "SomeName",
+        thread_fingerprint: "85bb6139",
+        message: "Some Message",
+        time: "2007-01-01T00:00:00.000Z",
+        tags: ["kek"],
+        named_tags: { id:  "very-long-id" },
       )
     end
   end


### PR DESCRIPTION
# Changes

## Features

- Add `tags` field, which represents array of tags.

## Fixes

- Rename `app_tags` to `named_tags`.