### PR TITLE
Fix warning in Rails 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 
@@ -151,4 +152,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.31
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.4.2)
+    umbrellio-utils (0.4.3)
       memery (~> 1)
 
 GEM
@@ -152,4 +152,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.33
+   2.3.0

--- a/lib/umbrellio_utils/request_wrapper.rb
+++ b/lib/umbrellio_utils/request_wrapper.rb
@@ -53,7 +53,7 @@ module UmbrellioUtils
     attr_accessor :request
 
     def parse_params
-      case request.content_type
+      case request.media_type
       when "application/json"
         Parsing.safely_parse_json(body)
       when "application/xml"

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end


### PR DESCRIPTION
DEPRECATION WARNING: Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead.