### PR TITLE
Fixes for #table_sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.6.2)
+    umbrellio-utils (0.7.0)
       memery (~> 1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,87 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.6.2)
+    umbrellio-utils (0.7.0)
       memery (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activejob (= 7.0.4.2)
+      activerecord (= 7.0.4.2)
+      activestorage (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      actionview (= 7.0.4.2)
+      activejob (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.4.2)
+      actionview (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activerecord (= 7.0.4.2)
+      activestorage (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.4.2)
+      activesupport (= 7.0.4.2)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.4.2)
+      activesupport (= 7.0.4.2)
+      globalid (>= 0.3.6)
+    activemodel (7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activerecord (7.0.4.2)
+      activemodel (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+    activestorage (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activejob (= 7.0.4.2)
+      activerecord (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
     activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     amazing_print (1.4.0)
+    amq-protocol (2.3.2)
     ast (2.4.2)
+    builder (3.2.4)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    bunny (2.20.3)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
     ci-helper (0.5.0)
       colorize (~> 0.8)
       dry-inflector (~> 0.2)
@@ -24,17 +89,44 @@ GEM
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.2.0)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dry-inflector (0.3.0)
+    erubi (1.12.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
+    lamian (1.7.0)
+      rails (>= 4.2)
+    loofah (2.19.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
     memery (1.4.1)
       ruby2_keywords (~> 0.0.2)
     method_source (1.0.0)
+    mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
     nokogiri (1.14.1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -52,10 +144,45 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    rabbit_messaging (0.12.1)
+      bunny (~> 2.0)
+      lamian
+      rails (>= 5.2)
+      sneakers (~> 2.0)
+      tainbox
     racc (1.6.2)
-    rack (3.0.4.1)
+    rack (2.2.6.2)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails (7.0.4.2)
+      actioncable (= 7.0.4.2)
+      actionmailbox (= 7.0.4.2)
+      actionmailer (= 7.0.4.2)
+      actionpack (= 7.0.4.2)
+      actiontext (= 7.0.4.2)
+      actionview (= 7.0.4.2)
+      activejob (= 7.0.4.2)
+      activemodel (= 7.0.4.2)
+      activerecord (= 7.0.4.2)
+      activestorage (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      bundler (>= 1.15.0)
+      railties (= 7.0.4.2)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.5.0)
+      loofah (~> 2.19, >= 2.19.1)
+    railties (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rbtree (0.4.6)
     regexp_parser (2.7.0)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -108,9 +235,16 @@ GEM
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    self_data (1.3.0)
     semantic_logger (4.12.0)
       concurrent-ruby (~> 1.0)
     sequel (5.65.0)
+    sequel-batches (2.0.2)
+      sequel
+    serverengine (2.0.7)
+      sigdump (~> 0.2.2)
+    set (1.0.3)
+    sigdump (0.2.4)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -118,9 +252,26 @@ GEM
     simplecov-html (0.12.3)
     simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
+    sneakers (2.11.0)
+      bunny (~> 2.12)
+      concurrent-ruby (~> 1.0)
+      rake
+      serverengine (~> 2.0.5)
+      thor
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     symbiont-ruby (0.7.0)
+    table_sync (6.0.4)
+      memery
+      rabbit_messaging
+      rails
+      self_data
+    tainbox (2.1.2)
+      activesupport
     thor (1.2.1)
     timecop (0.9.6)
+    timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     umbrellio-sequel-plugins (0.11.0.143)
@@ -128,8 +279,12 @@ GEM
       symbiont-ruby
     unicode-display_width (2.4.2)
     webrick (1.7.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     yard (0.9.28)
       webrick (~> 1.7.0)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   arm64-darwin-20
@@ -153,8 +308,10 @@ DEPENDENCIES
   rubocop-config-umbrellio
   semantic_logger
   sequel
+  sequel-batches
   simplecov
   simplecov-lcov
+  table_sync
   timecop
   umbrellio-utils!
   yard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (0.7.0)
+    umbrellio-utils (0.6.2)
       memery (~> 1)
 
 GEM

--- a/lib/umbrellio_utils/misc.rb
+++ b/lib/umbrellio_utils/misc.rb
@@ -12,7 +12,7 @@ module UmbrellioUtils
         model_class = batch_for_sync.first.class.name
         TableSync::Publishing::Batch.new(
           object_class: model_class,
-          original_attributes: batch_for_sync.map { |model| model.values },
+          original_attributes: batch_for_sync.map(&:values),
           routing_key: routing_key,
         ).publish_now
 

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "0.6.2"
+  VERSION = "0.7.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ require "semantic_logger"
 require "sequel"
 require "table_sync"
 require "timecop"
+
 require "umbrellio-utils"
 
 Dir[Pathname(__dir__).join("support/**/*")].sort.each { |x| require(x) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,10 +29,20 @@ require "semantic_logger"
 require "sequel"
 require "table_sync"
 require "timecop"
+require "rabbit/test_helpers"
 
 require "umbrellio-utils"
 
 Dir[Pathname(__dir__).join("support/**/*")].sort.each { |x| require(x) }
+
+TableSync.orm = :sequel
+TableSync.headers_callable = -> (_klass, attributes) { attributes.slice(:id) }
+
+Rabbit.configure do |config|
+  config.project_id = :umbrellio_utils
+  config.group_id = :umbrellio_utils
+  config.environment = :test
+end
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
@@ -43,6 +53,7 @@ RSpec.configure do |config|
   config.expose_dsl_globally = true
 
   config.include(RSpec::JsonMatcher)
+  config.include(Rabbit::TestHelpers)
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,8 +27,8 @@ require "nori"
 require "rspec/json_matcher"
 require "semantic_logger"
 require "sequel"
+require "table_sync"
 require "timecop"
-
 require "umbrellio-utils"
 
 Dir[Pathname(__dir__).join("support/**/*")].sort.each { |x| require(x) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,12 +24,12 @@ require "bundler/setup"
 require "active_support/all"
 require "nokogiri"
 require "nori"
-require "rabbit/test_helpers"
 require "rspec/json_matcher"
 require "semantic_logger"
 require "sequel"
 require "table_sync"
 require "timecop"
+require "rabbit/test_helpers"
 
 require "umbrellio-utils"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,12 +24,12 @@ require "bundler/setup"
 require "active_support/all"
 require "nokogiri"
 require "nori"
+require "rabbit/test_helpers"
 require "rspec/json_matcher"
 require "semantic_logger"
 require "sequel"
 require "table_sync"
 require "timecop"
-require "rabbit/test_helpers"
 
 require "umbrellio-utils"
 

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -15,6 +15,8 @@ DB.logger = Logger.new("log/db.log")
 
 Sequel::Model.db = DB
 
+DB.extension :batches
+
 DB.drop_table? :users
 DB.create_table :users do
   primary_key :id

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -24,5 +24,7 @@ DB.create_table :users do
 end
 
 class User < Sequel::Model(:users)
-  def skip_table_sync?; end
+  def skip_table_sync?
+    false
+  end
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -24,4 +24,5 @@ DB.create_table :users do
 end
 
 class User < Sequel::Model(:users)
+  def skip_table_sync?; end
 end

--- a/spec/umbrellio_utils/misc_spec.rb
+++ b/spec/umbrellio_utils/misc_spec.rb
@@ -24,6 +24,7 @@ describe UmbrellioUtils::Misc do
     end
 
     before do
+      User.define_method(:skip_table_sync?) { nil }
       User.create(email: "user1@mail.com")
       User.create(email: "user2@mail.com")
     end
@@ -50,7 +51,7 @@ describe UmbrellioUtils::Misc do
 
     context "without skipped users" do
       before do
-        User.define_method(:skip_table_sync?) { false }
+        allow_any_instance_of(User).to receive(:skip_table_sync?).and_return(false)
       end
 
       let(:expected_rabbit_attributes) do
@@ -69,8 +70,8 @@ describe UmbrellioUtils::Misc do
 
     context "when first user should be skipped" do
       before do
-        User.define_method(:skip_table_sync?) do
-          self.id == 1
+        allow_any_instance_of(User).to receive(:skip_table_sync?) do |user|
+          user.id == 1
         end
       end
 
@@ -87,7 +88,7 @@ describe UmbrellioUtils::Misc do
 
     context "when all users should be skipped" do
       before do
-        User.define_method(:skip_table_sync?) { true }
+        allow_any_instance_of(User).to receive(:skip_table_sync?).and_return(true)
       end
 
       it "doesn't publish message" do

--- a/spec/umbrellio_utils/misc_spec.rb
+++ b/spec/umbrellio_utils/misc_spec.rb
@@ -28,6 +28,10 @@ describe UmbrellioUtils::Misc do
       User.create(email: "user2@mail.com")
     end
 
+    after do
+      User.where(email: ["user1@mail.com", "user2@mail.com"]).destroy
+    end
+
     let(:rabbit_data) do
       {
         confirm_select: true,
@@ -46,13 +50,13 @@ describe UmbrellioUtils::Misc do
       }
     end
 
-    let(:users) { User.where(id: [1, 2]) }
+    let(:users) { User.where(email: ["user1@mail.com", "user2@mail.com"]) }
 
     context "without skipped users" do
       let(:expected_rabbit_attributes) do
         [
-          { email: "user1@mail.com", id: 1 },
-          { email: "user2@mail.com", id: 2 },
+          { email: "user1@mail.com", id: Numeric },
+          { email: "user2@mail.com", id: Numeric },
         ]
       end
 
@@ -66,12 +70,12 @@ describe UmbrellioUtils::Misc do
     context "when first user should be skipped" do
       before do
         allow_any_instance_of(User).to receive(:skip_table_sync?) do |user|
-          user.id == 1
+          user.email == "user1@mail.com"
         end
       end
 
       let(:expected_rabbit_attributes) do
-        [{ email: "user2@mail.com", id: 2 }]
+        [{ email: "user2@mail.com", id: Numeric }]
       end
 
       it "publishes only second user's data" do

--- a/spec/umbrellio_utils/misc_spec.rb
+++ b/spec/umbrellio_utils/misc_spec.rb
@@ -24,7 +24,6 @@ describe UmbrellioUtils::Misc do
     end
 
     before do
-      User.define_method(:skip_table_sync?) { nil }
       User.create(email: "user1@mail.com")
       User.create(email: "user2@mail.com")
     end
@@ -50,10 +49,6 @@ describe UmbrellioUtils::Misc do
     let(:users) { User.where(id: [1, 2]) }
 
     context "without skipped users" do
-      before do
-        allow_any_instance_of(User).to receive(:skip_table_sync?).and_return(false)
-      end
-
       let(:expected_rabbit_attributes) do
         [
           { email: "user1@mail.com", id: 1 },

--- a/spec/umbrellio_utils/misc_spec.rb
+++ b/spec/umbrellio_utils/misc_spec.rb
@@ -35,7 +35,7 @@ describe UmbrellioUtils::Misc do
       User.create(email: "user1@mail.com")
       User.create(email: "user2@mail.com")
       Array.alias_method(:in_batches, :each)
-      stub_const("TableSync::Publishing::Batch", table_sync_stub)
+      allow(TableSync::Publishing::Batch).to receive(:new).and_return(publisher)
     end
 
     let(:users) do
@@ -45,14 +45,11 @@ describe UmbrellioUtils::Misc do
       ]
     end
 
-    let(:table_sync_stub) do
-      class_double("TableSync::Publishing::Batch").tap do |klass|
-        allow(klass).to receive(:new).and_return(publisher)
-      end
-    end
-
     let(:publisher) do
-      instance_double("TableSync::Publishing::Batch").tap do |instance|
+      TableSync::Publishing::Batch.new(
+        object_class: "User",
+        original_attributes: [{ some: "data" }],
+      ).tap do |instance|
         allow(instance).to receive(:publish_now)
       end
     end

--- a/spec/umbrellio_utils/misc_spec.rb
+++ b/spec/umbrellio_utils/misc_spec.rb
@@ -17,4 +17,73 @@ describe UmbrellioUtils::Misc do
       end
     end
   end
+
+  describe "::table_sync" do
+    def run!
+      described_class.table_sync(users)
+    end
+
+    def expect_user_publishing(user_id)
+      expect(TableSync::Publishing::Batch).to have_received(:new).with(
+        object_class: "User",
+        original_attributes: [{ id: user_id, email: "user#{user_id}@mail.com" }],
+        routing_key: nil,
+      )
+    end
+
+    before do
+      User.create(email: "user1@mail.com")
+      User.create(email: "user2@mail.com")
+      Array.alias_method(:in_batches, :each)
+      stub_const("TableSync::Publishing::Batch", table_sync_stub)
+    end
+
+    let(:users) do
+      [
+        User.where(id: 1),
+        User.where(id: 2),
+      ]
+    end
+
+    let(:table_sync_stub) do
+      class_double("TableSync::Publishing::Batch").tap do |klass|
+        allow(klass).to receive(:new).and_return(publisher)
+      end
+    end
+
+    let(:publisher) do
+      instance_double("TableSync::Publishing::Batch").tap do |instance|
+        allow(instance).to receive(:publish_now)
+      end
+    end
+
+    context "without skipped users" do
+      before do
+        User.define_method(:skip_table_sync?) { false }
+      end
+
+      it "publishes all data" do
+        run!
+
+        expect_user_publishing(1)
+        expect_user_publishing(2)
+        expect(publisher).to have_received(:publish_now).exactly(2).times
+      end
+    end
+
+    context "with skipped users" do
+      before do
+        User.define_method(:skip_table_sync?) do
+          self.id == 1
+        end
+      end
+
+      it "publishes only second user's data" do
+        run!
+
+        expect_user_publishing(2)
+        expect(publisher).to have_received(:publish_now)
+      end
+    end
+  end
 end

--- a/umbrellio_utils.gemspec
+++ b/umbrellio_utils.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"
+  spec.add_development_dependency "table_sync"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "yard"
 end

--- a/umbrellio_utils.gemspec
+++ b/umbrellio_utils.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-config-umbrellio"
   spec.add_development_dependency "semantic_logger"
   spec.add_development_dependency "sequel"
+  spec.add_development_dependency "sequel-batches"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"
   spec.add_development_dependency "table_sync"


### PR DESCRIPTION
- в связи с выпиливанием класса `TableSync::Publishing::Publisher` в новой версии гема `table_sync` заменил данный класс на `TableSync::Publishing::Batch`
-  добавил тесты для метода `table_sync`