### PR TITLE
RequestWrapper param for preserving XML attributes

### DIFF
--- a/lib/umbrellio_utils/request_wrapper.rb
+++ b/lib/umbrellio_utils/request_wrapper.rb
@@ -4,8 +4,9 @@ module UmbrellioUtils
   class RequestWrapper
     include Memery
 
-    def initialize(request)
+    def initialize(request, remove_xml_attributes: true)
       self.request = request
+      self.remove_xml_attributes = remove_xml_attributes
     end
 
     memoize def params
@@ -50,14 +51,14 @@ module UmbrellioUtils
 
     private
 
-    attr_accessor :request
+    attr_accessor :request, :remove_xml_attributes
 
     def parse_params
       case request.media_type
       when "application/json", /\+json\z/
         Parsing.safely_parse_json(body)
       when "application/xml"
-        Parsing.parse_xml(body)
+        Parsing.parse_xml(body, remove_attributes: remove_xml_attributes)
       else
         request.get? ? request.GET : request.POST
       end

--- a/spec/umbrellio_utils/request_wrapper_spec.rb
+++ b/spec/umbrellio_utils/request_wrapper_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe UmbrellioUtils::RequestWrapper do
-  subject(:wrapped_request) { described_class.new(request, remove_xml_attributes:) }
+  subject(:wrapped_request) do
+    described_class.new(request, remove_xml_attributes: remove_xml_attributes)
+  end
 
   let(:request_body) { Hash[some: "value"].to_json }
   let(:content_type) { "application/json" }
@@ -37,12 +39,19 @@ describe UmbrellioUtils::RequestWrapper do
     context "with application/xml content-type" do
       let(:content_type) { "application/xml" }
       let(:request_body) do
-        "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" \
-          "<transaction><expiryDate month=\"02\" year=\"2024\"/><description>123</description></transaction>"
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8" ?>
+          <transaction>
+            <expiryDate month="02" year="2024"/>
+            <description>123</description>
+          </transaction>
+        XML
       end
 
       specify do
-        expect(wrapped_request.params).to eq({ transaction: { expiry_date: nil, description: "123" } })
+        expect(wrapped_request.params).to eq({
+          transaction: { expiry_date: nil, description: "123" },
+        })
       end
 
       context "with invalid xml" do

--- a/spec/umbrellio_utils/request_wrapper_spec.rb
+++ b/spec/umbrellio_utils/request_wrapper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe UmbrellioUtils::RequestWrapper do
-  subject(:wrapped_request) { described_class.new(request) }
+  subject(:wrapped_request) { described_class.new(request, remove_xml_attributes:) }
 
   let(:request_body) { Hash[some: "value"].to_json }
   let(:content_type) { "application/json" }
@@ -17,6 +17,7 @@ describe UmbrellioUtils::RequestWrapper do
       "REMOTE_ADDR" => "192.168.0.1",
     }
   end
+  let(:remove_xml_attributes) { true }
 
   describe "#params" do
     context "with application/json content-type" do
@@ -36,11 +37,12 @@ describe UmbrellioUtils::RequestWrapper do
     context "with application/xml content-type" do
       let(:content_type) { "application/xml" }
       let(:request_body) do
-        "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> <transaction>123</transaction>"
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" \
+          "<transaction><expiryDate month=\"02\" year=\"2024\"/><description>123</description></transaction>"
       end
 
       specify do
-        expect(wrapped_request.params).to eq({ transaction: "123" })
+        expect(wrapped_request.params).to eq({ transaction: { expiry_date: nil, description: "123" } })
       end
 
       context "with invalid xml" do
@@ -48,6 +50,19 @@ describe UmbrellioUtils::RequestWrapper do
 
         specify do
           expect(wrapped_request.params).to eq({})
+        end
+      end
+
+      context "with remove_xml_attributes = false" do
+        let(:remove_xml_attributes) { false }
+
+        it "does not remove attributes" do
+          expect(wrapped_request.params).to eq({
+            transaction: {
+              expiry_date: { "@month": "02", "@year": "2024" },
+              description: "123",
+            },
+          })
         end
       end
     end


### PR DESCRIPTION
In some cases it's useful to preserve XML attributes in request parameters. I have added RequestWrapper param which controls preserving behavior (`remove_xml_attributes`).