### PR TITLE
Fix email check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    umbrellio-utils (1.5.1)
+    umbrellio-utils (1.5.2)
       memery (~> 1)
 
 GEM

--- a/lib/umbrellio_utils/checks.rb
+++ b/lib/umbrellio_utils/checks.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require "uri/mailto"
+
 module UmbrellioUtils
   module Checks
     extend self
 
-    EMAIL_REGEXP = /\A([\w+-].?)+@[a-z\d-]+(\.[a-z]+)*\.[a-z]+\z/i
     HOLDER_NAME_REGEXP = /\A([A-Za-z0-9.'-]+ ?)+\z/
 
     def secure_compare(src, dest)
@@ -30,11 +31,11 @@ module UmbrellioUtils
     end
 
     def valid_email?(email)
-      email.to_s =~ EMAIL_REGEXP
+      email.to_s.match?(URI::MailTo::EMAIL_REGEXP)
     end
 
     def valid_card_holder?(holder)
-      holder.to_s =~ HOLDER_NAME_REGEXP
+      holder.to_s.match?(HOLDER_NAME_REGEXP)
     end
 
     def valid_card_cvv?(cvv)

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end

--- a/spec/umbrellio_utils/checks_spec.rb
+++ b/spec/umbrellio_utils/checks_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe UmbrellioUtils::Checks do
+  describe "#valid_email?" do
+    subject(:result) { described_class.valid_email?(input) }
+
+    let(:input) { "user@example.com" }
+
+    it { is_expected.to eq(true) }
+
+    context "invalid input" do
+      let(:input) { "invalid" }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "input with subdomains and digits" do
+      let(:input) { "user@one.two42.com" }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "non-string input" do
+      let(:input) { 123 }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/umbrellio_utils/checks_spec.rb
+++ b/spec/umbrellio_utils/checks_spec.rb
@@ -4,26 +4,21 @@ describe UmbrellioUtils::Checks do
   describe "#valid_email?" do
     subject(:result) { described_class.valid_email?(input) }
 
-    let(:input) { "user@example.com" }
+    expectations = {
+      "user@example.com" => true,
+      "user@one.two42.com" => true,
+      "invalid" => false,
+      123 => false,
+      nil => false,
+    }
 
-    it { is_expected.to eq(true) }
+    expectations.each do |input, expected_result|
+      context "with input #{input.inspect} should return #{expected_result.inspect}" do
+        let(:input) { input }
+        let(:expected_result) { expected_result }
 
-    context "invalid input" do
-      let(:input) { "invalid" }
-
-      it { is_expected.to eq(false) }
-    end
-
-    context "input with subdomains and digits" do
-      let(:input) { "user@one.two42.com" }
-
-      it { is_expected.to eq(true) }
-    end
-
-    context "non-string input" do
-      let(:input) { 123 }
-
-      it { is_expected.to eq(false) }
+        it { is_expected.to eq(expected_result) }
+      end
     end
   end
 end


### PR DESCRIPTION
Короче емейл вида `user@one.two42.com` считался невалидным ¯\\\_(ツ)_/¯ 