### PR TITLE
Fix backslash escaping in ClickHouse string literals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    umbrellio-utils (1.13.1)
+    umbrellio-utils (1.13.2)
       memery (~> 1)
 
 GEM

--- a/lib/umbrellio_utils/click_house/backends/base.rb
+++ b/lib/umbrellio_utils/click_house/backends/base.rb
@@ -13,6 +13,15 @@ module UmbrellioUtils
       class Base
         include Singleton
 
+        # ClickHouse uses C-style escape sequences in string literals, so
+        # backslashes must be doubled. Sequel's default (Postgres) escaping
+        # only escapes single-quotes.
+        module ClickHouseStringEscaping
+          def literal_string_append(sql, v)
+            sql << "'" << v.gsub("\\") { "\\\\" }.gsub("'", "''") << "'"
+          end
+        end
+
         # Concrete backends implement the low-level ops (execute / query /
         # insert / describe_table / server_version / tables / admin_execute
         # / config / logger) and define SERVER_ERROR.
@@ -27,7 +36,7 @@ module UmbrellioUtils
             else
               DB.from(source)
             end
-          ds.clone(ch: true)
+          ds.clone(ch: true).with_extend(ClickHouseStringEscaping)
         end
 
         def count(dataset)

--- a/lib/umbrellio_utils/click_house/backends/base.rb
+++ b/lib/umbrellio_utils/click_house/backends/base.rb
@@ -17,8 +17,8 @@ module UmbrellioUtils
         # backslashes must be doubled. Sequel's default (Postgres) escaping
         # only escapes single-quotes.
         module ClickHouseStringEscaping
-          def literal_string_append(sql, v)
-            sql << "'" << v.gsub("\\") { "\\\\" }.gsub("'", "''") << "'"
+          def literal_string_append(sql, str)
+            sql << "'" << str.gsub("\\") { "\\\\" }.gsub("'", "''") << "'"
           end
         end
 

--- a/lib/umbrellio_utils/version.rb
+++ b/lib/umbrellio_utils/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UmbrellioUtils
-  VERSION = "1.13.1"
+  VERSION = "1.13.2"
 end

--- a/spec/umbrellio_utils/clickhouse_spec.rb
+++ b/spec/umbrellio_utils/clickhouse_spec.rb
@@ -31,6 +31,28 @@ describe UmbrellioUtils::ClickHouse do
         )
       end
     end
+
+    context "string literal escaping" do
+      # ClickHouse uses C-style escape sequences; backslash must be doubled.
+      # Ruby "foo\\bar" == the string foo\bar (one backslash).
+      # Expected SQL: 'foo\\bar' (two chars \\ so CH sees one literal \).
+      it "doubles backslashes so ClickHouse C-style escaping is safe" do
+        ds = ch.from(:test).where(Sequel[:name] => "foo\\bar")
+        expect(ds.sql).to include("'foo\\\\bar'")
+      end
+
+      it "escapes single quotes" do
+        ds = ch.from(:test).where(Sequel[:name] => "foo'bar")
+        expect(ds.sql).to include("'foo''bar'")
+      end
+
+      # Input: foo\'bar  (backslash then quote)
+      # Expected SQL: 'foo\\''bar'  (\\ for the backslash, '' for the quote)
+      it "handles backslash immediately before single quote" do
+        ds = ch.from(:test).where(Sequel[:name] => "foo\\'bar")
+        expect(ds.sql).to include("'foo\\\\''bar'")
+      end
+    end
   end
 
   describe "#query" do


### PR DESCRIPTION
ClickHouse uses C-style escape sequences so backslashes in string literals must be doubled. Sequel's Postgres adapter only escapes single-quotes, leaving bare backslashes that ClickHouse misinterprets (e.g. \' breaks query boundaries).

Override literal_string_append via a dataset module mixed into every CH dataset returned by Base#from, so the fix applies through all Sequel chaining.